### PR TITLE
✨ Build image for multiple architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
       - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v1
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
           build-args: PHP=${{ matrix.php }}
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ steps.push.outputs.sha }}


### PR DESCRIPTION
Adds `linux/arm64` (along with the default `linux/amd64`) to platforms that the image is built for, with opportunity to add more in future using the `Build Image` step `platforms` parameter.

https://github.com/shrink/docker-php-api/blob/c293fafead74dcf1ee50122601a6e2e99e7d0062/.github/workflows/build.yml#L33-L46