### PR TITLE
ci: Set up QEMU for loading multii-arch images

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,7 @@ jobs:
       image: "ghcr.io/${{ github.repository }}"
       archive: "docker-php-api-${{ matrix.php }}.tar"
     steps:
+      - uses: docker/setup-qemu-action@v1
       - name: Download Docker Image from build workflow
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
I think this might fix the error here https://github.com/shrink/docker-php-api/actions/runs/883853575

```
open /var/lib/docker/tmp/docker-import-130271302/linux_amd64/json: no such file or directory
```