### PR TITLE
ci: Output using `docker` type for subsequent loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,12 @@ jobs:
         id: build
         uses: docker/build-push-action@v2
         with:
-          builder: "${{ steps.buildx.outputs.name }}"
           build-args: PHP=${{ matrix.php }}
+          builder: "${{ steps.buildx.outputs.name }}"
           labels: "${{ steps.meta.outputs.labels }}"
-          outputs: "type=oci,dest=${{ env.archive }}"
-          tags: "${{ steps.meta.outputs.tags }}"
+          outputs: "type=docker,dest=${{ env.archive }}"
           platforms: "${{ steps.buildx.outputs.platforms }}"
+          tags: "${{ steps.meta.outputs.tags }}"
       - name: Upload Docker Image as pipeline artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
+        id: buildx
       - uses: docker/setup-qemu-action@v1
       - name: Generate branch Docker Image attributes
         id: meta
@@ -29,10 +30,12 @@ jobs:
         id: build
         uses: docker/build-push-action@v2
         with:
+          builder: "${{ steps.buildx.outputs.name }}"
           build-args: PHP=${{ matrix.php }}
           labels: "${{ steps.meta.outputs.labels }}"
-          outputs: "type=tar,dest=${{ env.archive }}"
+          outputs: "type=oci,dest=${{ env.archive }}"
           tags: "${{ steps.meta.outputs.tags }}"
+          platforms: "${{ steps.buildx.outputs.platforms }}"
       - name: Upload Docker Image as pipeline artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
           builder: "${{ steps.buildx.outputs.name }}"
           labels: "${{ steps.meta.outputs.labels }}"
           outputs: "type=docker,dest=${{ env.archive }}"
-          platforms: "${{ steps.buildx.outputs.platforms }}"
           tags: "${{ steps.meta.outputs.tags }}"
       - name: Upload Docker Image as pipeline artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
       archive: "docker-php-api-${{ matrix.php }}.tar"
     steps:
       - uses: docker/setup-buildx-action@v1
-        id: buildx
       - uses: docker/setup-qemu-action@v1
       - name: Generate branch Docker Image attributes
         id: meta
@@ -29,9 +28,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: PHP=${{ matrix.php }}
-          builder: "${{ steps.buildx.outputs.name }}"
           labels: "${{ steps.meta.outputs.labels }}"
-          outputs: "type=oci,dest=${{ env.archive }}"
+          outputs: "type=docker,dest=${{ env.archive }}"
           tags: "${{ steps.meta.outputs.tags }}"
       - name: Upload Docker Image as pipeline artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
       image: "ghcr.io/${{ github.repository }}"
       archive: "docker-php-api-${{ matrix.php }}.tar"
     steps:
-      - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
         id: buildx
       - uses: docker/setup-qemu-action@v1
@@ -27,13 +26,12 @@ jobs:
           images: "${{ env.image }}"
           tags: "type=sha,suffix=-${{ matrix.php }}"
       - name: Build Docker Image
-        id: build
         uses: docker/build-push-action@v2
         with:
           build-args: PHP=${{ matrix.php }}
           builder: "${{ steps.buildx.outputs.name }}"
           labels: "${{ steps.meta.outputs.labels }}"
-          outputs: "type=docker,dest=${{ env.archive }}"
+          outputs: "type=oci,dest=${{ env.archive }}"
           tags: "${{ steps.meta.outputs.tags }}"
       - name: Upload Docker Image as pipeline artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,5 @@ jobs:
         uses: benjlevesque/short-sha@v1.2
       - name: Push Docker Image to Registry
         run: |
-          docker import ${{ env.archive }} ${{ env.image }}:${{ env.tag }}
+          docker load --import ${{ env.archive }}
           docker push --all-tags ${{ env.image }}
-        env:
-          tag: "sha-${{ steps.short.outputs.sha }}-${{ matrix.php }}"


### PR DESCRIPTION
The `tar` output type includes the filesystem, not the full image. The only suitable output type is `docker` but unfortunately this type doesn't support multiple architectures in one image.