### PR TITLE
fix: Allow php-fpm to run as root

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-php-fpm -g /tmp/php-fpm.pid -F &
+php-fpm --allow-to-run-as-root -g /tmp/php-fpm.pid -F &
 
 until [ -f /tmp/php-fpm.pid ]; do usleep 10000; done
 


### PR DESCRIPTION
The container _should_ run as `nobody` (as is specified within the Dockerfile) but it's possible that a use-case may require the container run as root. The decision of which user to run as should not be blocked by php-fpm: without `--allow-to-run-as-root` this image is not compatible with fly.io.